### PR TITLE
Fix column widths

### DIFF
--- a/Gakumas-Tool/save_to_excel.py
+++ b/Gakumas-Tool/save_to_excel.py
@@ -48,7 +48,12 @@ def merge_lines(raw_lines: list[RawLine], existing_tl_lines: list[TranslationLin
     return new_tl_lines
 
 
-def save_to_excel(raw_lines: list[RawLine], output_path: str, worksheet_name: str):
+def save_to_excel(
+    raw_lines: list[RawLine],
+    output_path: str,
+    worksheet_name: str,
+    force_overwrite: bool,
+):
     try:
         existing_tl_lines = get_tl_lines_from_spreadsheet(output_path, worksheet_name)
     except FileNotFoundError:
@@ -56,8 +61,9 @@ def save_to_excel(raw_lines: list[RawLine], output_path: str, worksheet_name: st
 
     # Don't do anything if the raw data from the commu files
     # is the same as the raw data from the existing spreadsheet
+    # and we aren't force overwriting
     existing_raw_lines = [to_raw_line(tl_line) for tl_line in existing_tl_lines]
-    if raw_lines == existing_raw_lines:
+    if not force_overwrite and raw_lines == existing_raw_lines:
         print(f"No change in raw lines in {output_path}, skipping...")
         return
 

--- a/Gakumas-Tool/spreadsheet.py
+++ b/Gakumas-Tool/spreadsheet.py
@@ -34,7 +34,7 @@ def get_tl_lines_from_spreadsheet(
     ]
 
     # check it has the right column headers
-    existing_column_headers = existing_rows[0]
+    existing_column_headers = tuple(str(header) for header in existing_rows[0])
     if existing_column_headers != column_headers:
         raise Exception(
             f"Existing spreadsheet has incorrect column headers!"

--- a/Gakumas-Tool/spreadsheet.py
+++ b/Gakumas-Tool/spreadsheet.py
@@ -1,5 +1,6 @@
 import openpyxl
 import openpyxl.styles
+import os
 from data_types import TranslationLine
 
 column_headers = ("type", "name", "translated name", "text", "translated text")
@@ -71,8 +72,13 @@ def write_tl_lines_to_spreadsheet(
     worksheet.column_dimensions["A"].width = 15  # type column
     worksheet.column_dimensions["B"].width = 15  # name column
     worksheet.column_dimensions["C"].width = 15  # translated name column
-    worksheet.column_dimensions["D"].width = 40  # text column
-    worksheet.column_dimensions["E"].width = 40  # translated column
+    # Text columns have larger widths if it's a main story commu
+    if os.path.basename(output_path).startswith("adv_unit_"):
+        worksheet.column_dimensions["D"].width = 70  # text column
+        worksheet.column_dimensions["E"].width = 70  # translated column
+    else:
+        worksheet.column_dimensions["D"].width = 38  # text column
+        worksheet.column_dimensions["E"].width = 38  # translated column
 
     # Define formats for cell alignment and text wrapping
     dialogue_alignment = openpyxl.styles.Alignment(

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ To force the program to process all commu files, include the flag `-a`
 ```bash
 pipenv run python Gakumas-Tool/main.py extract -a txt_directory xlsx_directory
 ```
+By default, the program will skip generating commu files where the raw text
+data is the same.
+To force the program to generate commu files where the raw text is the same,
+include the flag `-f`
+```bash
+pipenv run python Gakumas-Tool/main.py extract -f txt_directory xlsx_directory
+```
 
 ### Injecting translations
 


### PR DESCRIPTION
Set smaller column widths, except for story commus (those with filename beginning with `adv_unit`
Also adds a command-line option to force overwrite xlsx files where no raw text has changed