### PR TITLE
Script to deduplicate description objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 
-/Gakumas-Tool/__pycache__
+*/__pycache__

--- a/Descriptions/descriptions.py
+++ b/Descriptions/descriptions.py
@@ -1,0 +1,104 @@
+import json
+
+description_defaults = {
+    "produceDescriptionType": "ProduceDescriptionType_Unknown",
+    "examDescriptionType": "ExamDescriptionType_Unknown",
+    "examEffectType": "ProduceExamEffectType_Unknown",
+    "produceCardCategory": "ProduceCardCategory_Unknown",
+    "produceCardMovePositionType": "ProduceCardMovePositionType_Unknown",
+    "produceStepType": "ProduceStepType_Unknown",
+    "targetId": "",
+    "text": "",
+}
+
+descriptions: dict[str, dict] = {}
+other_descriptions: list[dict] = []
+
+
+def strip_defaults(description):
+    for key, value in description_defaults.items():
+        if description[key] == value:
+            description.pop(key)
+
+
+def get_index(description):
+    try:
+        return other_descriptions.index(description)
+    except ValueError:
+        other_descriptions.append(description)
+        index = len(other_descriptions) - 1
+        descriptions[f"other:{index}"] = description
+        return index
+
+
+def is_plain_string(description):
+    if (
+        description.get("produceDescriptionType", "")
+        != "ProduceDescriptionType_PlainText"
+    ):
+        return False
+    if "text" not in description:
+        description["text"] = ""
+    return description.keys() == {"produceDescriptionType", "text"}
+
+
+exam_customise_head = "ExamDescriptionType_Customize"
+
+
+def is_exam_customize(description):
+    if description.get("produceDescriptionType", "") != "ProduceDescriptionType_Exam":
+        return False
+    if not (description.get("examDescriptionType", "").startswith(exam_customise_head)):
+        return False
+    if "text" not in description:
+        description["text"] = ""
+    return description.keys() == {
+        "produceDescriptionType",
+        "examDescriptionType",
+        "text",
+    }
+
+
+def get_id(description):
+    id = ""
+
+    target_id = description.get("targetId", "")
+    if target_id != "":
+        id = f"id:{target_id}"
+    elif is_plain_string(description):
+        id = f"text:{description["text"]}"
+    elif is_exam_customize(description):
+        custom_type = description["examDescriptionType"][len(exam_customise_head) :]
+        id = f"custom:{custom_type}:{description["text"]}"
+
+    if id != "":
+        if id not in descriptions:
+            descriptions[id] = description
+        if descriptions[id] != description:
+            return get_index(description)
+        return id
+
+    return get_index(description)
+
+
+def process_json(filename: str, out_filename: str):
+    in_file = open(filename, encoding="utf8")
+    json_object = json.load(in_file)
+    in_file.close()
+
+    for item in json_object["data"]:
+        for description in item["produceDescriptions"]:
+            strip_defaults(description)
+        item_descriptions = item.pop("produceDescriptions")
+        descriptionIndexes = [get_id(desc_item) for desc_item in item_descriptions]
+        item["produceDescriptionIndexes"] = descriptionIndexes
+
+    json_object["descriptions"] = dict(sorted(descriptions.items()))
+
+    out_file = open(out_filename, "w", encoding="utf8")
+    # json.dump(
+    #     json_object, out_file, ensure_ascii=False, indent=None, separators=(",", ":")
+    # )
+    json.dump(json_object, out_file, ensure_ascii=False, indent=2)
+    out_file.close()
+    pass

--- a/Descriptions/descriptions.py
+++ b/Descriptions/descriptions.py
@@ -120,14 +120,15 @@ class DescriptionStore:
         else:
             return ""
 
-    def get_other_index(self, description):
+    def get_other_id(self, description):
         try:
-            return self.other_descriptions.index(description)
+            index = self.other_descriptions.index(description)
+            return f"~other:{index}"
         except ValueError:
             self.other_descriptions.append(description)
             index = len(self.other_descriptions) - 1
             self.descriptions[f"~other:{index}"] = description
-            return index
+            return f"~other:{index}"
 
     def get_id(self, description):
         id = self.get_hash(description)
@@ -135,9 +136,9 @@ class DescriptionStore:
             if id not in self.descriptions:
                 self.descriptions[id] = description
             if self.descriptions[id] != description:
-                return self.get_other_index(description)
+                return self.get_other_id(description)
             return id
-        return self.get_other_index(description)
+        return self.get_other_id(description)
 
     def print_descriptions(self, out_filename: str):
         sorted_descriptions = dict(sorted(self.descriptions.items()))

--- a/Descriptions/descriptions.py
+++ b/Descriptions/descriptions.py
@@ -27,7 +27,7 @@ def get_other_index(description):
     except ValueError:
         other_descriptions.append(description)
         index = len(other_descriptions) - 1
-        descriptions[f"other:{index}"] = description
+        descriptions[f"~other:{index}"] = description
         return index
 
 
@@ -35,6 +35,17 @@ def is_plain_string(description):
     if (
         description.get("produceDescriptionType", "")
         != "ProduceDescriptionType_PlainText"
+    ):
+        return False
+    if "text" not in description:
+        description["text"] = ""
+    return description.keys() == {"produceDescriptionType", "text"}
+
+
+def is_diff_string(description):
+    if (
+        description.get("produceDescriptionType", "")
+        != "ProduceDescriptionType_DiffText"
     ):
         return False
     if "text" not in description:
@@ -64,7 +75,9 @@ def get_hash(description):
     if target_id != "":
         return f"id:{target_id}"
     elif is_plain_string(description):
-        return f"text:{description["text"]}"
+        return f"plaintext:{description["text"]}"
+    elif is_diff_string(description):
+        return f"difftext:{description["text"]}"
     elif is_exam_customize(description):
         custom_type = description["examDescriptionType"][len(exam_customise_head) :]
         return f"custom:{custom_type}:{description["text"]}"

--- a/Descriptions/descriptions.py
+++ b/Descriptions/descriptions.py
@@ -1,155 +1,169 @@
 import json
 
-description_defaults = {
-    "produceDescriptionType": "ProduceDescriptionType_Unknown",
-    "examDescriptionType": "ExamDescriptionType_Unknown",
-    "examEffectType": "ProduceExamEffectType_Unknown",
-    "produceCardCategory": "ProduceCardCategory_Unknown",
-    "produceCardMovePositionType": "ProduceCardMovePositionType_Unknown",
-    "produceStepType": "ProduceStepType_Unknown",
-    "targetId": "",
-    "text": "",
-}
 
-descriptions: dict[str, dict] = {}
-other_descriptions: list[dict] = []
+class DescriptionStore:
+    descriptions: dict[str, dict]
+    other_descriptions: list[dict]
 
+    def __init__(self):
+        self.descriptions = {}
+        self.other_descriptions = []
 
-def strip_defaults(description):
-    for key, value in description_defaults.items():
-        if description[key] == value:
-            description.pop(key)
-
-
-def get_other_index(description):
-    try:
-        return other_descriptions.index(description)
-    except ValueError:
-        other_descriptions.append(description)
-        index = len(other_descriptions) - 1
-        descriptions[f"~other:{index}"] = description
-        return index
-
-
-def is_plain_string(description):
-    if (
-        description.get("produceDescriptionType", "")
-        != "ProduceDescriptionType_PlainText"
-    ):
-        return False
-    if "text" not in description:
-        description["text"] = ""
-    return description.keys() == {"produceDescriptionType", "text"}
-
-
-def is_diff_string(description):
-    if (
-        description.get("produceDescriptionType", "")
-        != "ProduceDescriptionType_DiffText"
-    ):
-        return False
-    if "text" not in description:
-        description["text"] = ""
-    return description.keys() == {"produceDescriptionType", "text"}
-
-
-exam_customise_head = "ExamDescriptionType_Customize"
-
-
-def is_exam_customize(description):
-    if description.get("produceDescriptionType", "") != "ProduceDescriptionType_Exam":
-        return False
-    if not (description.get("examDescriptionType", "").startswith(exam_customise_head)):
-        return False
-    if "text" not in description:
-        description["text"] = ""
-    return description.keys() == {
-        "produceDescriptionType",
-        "examDescriptionType",
-        "text",
+    description_defaults = {
+        "produceDescriptionType": "ProduceDescriptionType_Unknown",
+        "examDescriptionType": "ExamDescriptionType_Unknown",
+        "examEffectType": "ProduceExamEffectType_Unknown",
+        "produceCardCategory": "ProduceCardCategory_Unknown",
+        "produceCardMovePositionType": "ProduceCardMovePositionType_Unknown",
+        "produceStepType": "ProduceStepType_Unknown",
+        "targetId": "",
+        "text": "",
     }
 
-
-def get_hash(description):
-    target_id = description.get("targetId", "")
-    if target_id != "":
-        return f"id:{target_id}"
-    elif is_plain_string(description):
-        return f"plaintext:{description["text"]}"
-    elif is_diff_string(description):
-        return f"difftext:{description["text"]}"
-    elif is_exam_customize(description):
-        custom_type = description["examDescriptionType"][len(exam_customise_head) :]
-        return f"custom:{custom_type}:{description["text"]}"
-    else:
-        return ""
-
-
-def get_id(description):
-    id = get_hash(description)
-    if id != "":
-        if id not in descriptions:
-            descriptions[id] = description
-        if descriptions[id] != description:
-            return get_other_index(description)
-        return id
-    return get_other_index(description)
-
-
-desc_primary_key_suffixes = [
-    ".produceDescriptionType",
-    ".examDescriptionType",
-    ".examEffectType",
-    ".produceCardCategory",
-    ".produceCardMovePositionType",
-    ".produceStepType",
-    ".targetId",
-]
-
-
-def get_description_primary_key(primary_keys):
-    desc_primary_key_suffix = desc_primary_key_suffixes[0]
-    desc_primary_keys = [
-        key[: -len(desc_primary_key_suffix)]
-        for key in primary_keys
-        if key.endswith(desc_primary_key_suffix)
+    desc_primary_key_suffixes = [
+        ".produceDescriptionType",
+        ".examDescriptionType",
+        ".examEffectType",
+        ".produceCardCategory",
+        ".produceCardMovePositionType",
+        ".produceStepType",
+        ".targetId",
     ]
-    if len(desc_primary_keys) == 0:
-        raise ValueError("No primary key with the right suffix!")
 
-    desc_primary_key = desc_primary_keys[0]
-    if all(
-        [
-            (desc_primary_key + suffix) in primary_keys
-            for suffix in desc_primary_key_suffixes
+    @classmethod
+    def get_primary_key_prefix(cls, primary_keys):
+        desc_primary_key_suffix = cls.desc_primary_key_suffixes[0]
+        desc_primary_keys = [
+            key[: -len(desc_primary_key_suffix)]
+            for key in primary_keys
+            if key.endswith(desc_primary_key_suffix)
         ]
-    ):
-        return desc_primary_key
-    else:
-        raise ValueError("Primary key does not have all the right suffixes!")
+        if len(desc_primary_keys) == 0:
+            raise ValueError("No primary key with the right suffix!")
+
+        desc_primary_key = desc_primary_keys[0]
+        if all(
+            [
+                (desc_primary_key + suffix) in primary_keys
+                for suffix in cls.desc_primary_key_suffixes
+            ]
+        ):
+            return desc_primary_key
+        else:
+            raise ValueError("Primary key does not have all the right suffixes!")
+
+    @classmethod
+    def strip_defaults(cls, description):
+        for key, value in cls.description_defaults.items():
+            if description[key] == value:
+                description.pop(key)
+
+    @classmethod
+    def is_plain_string(cls, description):
+        if (
+            description.get("produceDescriptionType", "")
+            != "ProduceDescriptionType_PlainText"
+        ):
+            return False
+        if "text" not in description:
+            description["text"] = ""
+        return description.keys() == {"produceDescriptionType", "text"}
+
+    @classmethod
+    def is_diff_string(cls, description):
+        if (
+            description.get("produceDescriptionType", "")
+            != "ProduceDescriptionType_DiffText"
+        ):
+            return False
+        if "text" not in description:
+            description["text"] = ""
+        return description.keys() == {"produceDescriptionType", "text"}
+
+    exam_customise_head = "ExamDescriptionType_Customize"
+
+    @classmethod
+    def is_exam_customize(cls, description):
+        if (
+            description.get("produceDescriptionType", "")
+            != "ProduceDescriptionType_Exam"
+        ):
+            return False
+        if not (
+            description.get("examDescriptionType", "").startswith(
+                cls.exam_customise_head
+            )
+        ):
+            return False
+        if "text" not in description:
+            description["text"] = ""
+        return description.keys() == {
+            "produceDescriptionType",
+            "examDescriptionType",
+            "text",
+        }
+
+    @classmethod
+    def get_hash(cls, description):
+        target_id = description.get("targetId", "")
+        if target_id != "":
+            return f"id:{target_id}"
+        elif cls.is_plain_string(description):
+            return f"plaintext:{description["text"]}"
+        elif cls.is_diff_string(description):
+            return f"difftext:{description["text"]}"
+        elif cls.is_exam_customize(description):
+            custom_type = description["examDescriptionType"][
+                len(cls.exam_customise_head) :
+            ]
+            return f"custom:{custom_type}:{description["text"]}"
+        else:
+            return ""
+
+    def get_other_index(self, description):
+        try:
+            return self.other_descriptions.index(description)
+        except ValueError:
+            self.other_descriptions.append(description)
+            index = len(self.other_descriptions) - 1
+            self.descriptions[f"~other:{index}"] = description
+            return index
+
+    def get_id(self, description):
+        id = self.get_hash(description)
+        if id != "":
+            if id not in self.descriptions:
+                self.descriptions[id] = description
+            if self.descriptions[id] != description:
+                return self.get_other_index(description)
+            return id
+        return self.get_other_index(description)
+
+    def print_descriptions(self, out_filename: str):
+        sorted_descriptions = dict(sorted(self.descriptions.items()))
+        out_file = open(out_filename, "w", encoding="utf8")
+        json.dump(sorted_descriptions, out_file, ensure_ascii=False, indent=2)
+        out_file.close()
 
 
-def shorten_json(filename: str, out_filename: str):
+def shorten_json(description_store: DescriptionStore, filename: str, out_filename: str):
     in_file = open(filename, encoding="utf8")
     json_object = json.load(in_file)
     in_file.close()
 
-    desc_primary_key = get_description_primary_key(json_object["rules"]["primaryKeys"])
+    desc_primary_key = description_store.get_primary_key_prefix(
+        json_object["rules"]["primaryKeys"]
+    )
 
     for item in json_object["data"]:
         for description in item[desc_primary_key]:
-            strip_defaults(description)
+            description_store.strip_defaults(description)
         item_descriptions = item.pop(desc_primary_key)
-        descriptionIds = [get_id(desc_item) for desc_item in item_descriptions]
+        descriptionIds = [
+            description_store.get_id(desc_item) for desc_item in item_descriptions
+        ]
         item[desc_primary_key + "Ids"] = descriptionIds
 
     out_file = open(out_filename, "w", encoding="utf8")
     json.dump(json_object, out_file, ensure_ascii=False, indent=2)
-    out_file.close()
-
-
-def print_descriptions(out_filename: str):
-    sorted_descriptions = dict(sorted(descriptions.items()))
-    out_file = open(out_filename, "w", encoding="utf8")
-    json.dump(sorted_descriptions, out_file, ensure_ascii=False, indent=2)
     out_file.close()

--- a/Descriptions/descriptions.py
+++ b/Descriptions/descriptions.py
@@ -2,11 +2,11 @@ import json
 
 
 class DescriptionStore:
-    descriptions: dict[str, dict]
+    id_descriptions: dict[str, dict]
     other_descriptions: list[dict]
 
     def __init__(self):
-        self.descriptions = {}
+        self.id_descriptions = {}
         self.other_descriptions = []
 
     description_defaults = {
@@ -120,30 +120,35 @@ class DescriptionStore:
         else:
             return ""
 
-    def get_other_id(self, description):
+    def get_other_index(self, description):
         try:
-            index = self.other_descriptions.index(description)
-            return f"~other:{index}"
+            return self.other_descriptions.index(description)
         except ValueError:
             self.other_descriptions.append(description)
-            index = len(self.other_descriptions) - 1
-            self.descriptions[f"~other:{index}"] = description
-            return f"~other:{index}"
+            return len(self.other_descriptions) - 1
 
     def get_id(self, description):
         id = self.get_hash(description)
         if id != "":
-            if id not in self.descriptions:
-                self.descriptions[id] = description
-            if self.descriptions[id] != description:
-                return self.get_other_id(description)
+            if id not in self.id_descriptions:
+                self.id_descriptions[id] = description
+            if self.id_descriptions[id] != description:
+                return self.get_other_index(description)
             return id
-        return self.get_other_id(description)
+        return self.get_other_index(description)
 
     def print_descriptions(self, out_filename: str):
-        sorted_descriptions = dict(sorted(self.descriptions.items()))
+        sorted_descriptions = dict(sorted(self.id_descriptions.items()))
         out_file = open(out_filename, "w", encoding="utf8")
-        json.dump(sorted_descriptions, out_file, ensure_ascii=False, indent=2)
+        json.dump(
+            {
+                "id_descriptions": sorted_descriptions,
+                "other_descriptions": self.other_descriptions,
+            },
+            out_file,
+            ensure_ascii=False,
+            indent=2,
+        )
         out_file.close()
 
 

--- a/Descriptions/main.py
+++ b/Descriptions/main.py
@@ -1,7 +1,8 @@
 import argparse
 import sys
+import os
 
-from descriptions import shorten_json
+from descriptions import shorten_json, print_descriptions
 
 
 def create_argument_parser():
@@ -10,16 +11,37 @@ def create_argument_parser():
         description="Gakuen Idolm@ster card description conversion tool",
     )
     subparsers = parser.add_subparsers()
-    parser_extract = subparsers.add_parser("extract", help="Extracts data")
-    parser_extract.add_argument("json_file", help="The json file")
-    parser_extract.add_argument("output_file", help="The output file")
+    parser_extract = subparsers.add_parser("shorten", help="Shortens json files")
+    parser_extract.add_argument("json_dir", help="The folder containing the json files")
+    parser_extract.add_argument(
+        "out_dir", help="The folder to contain the output files"
+    )
     return parser
+
+
+def shorten_jsons(json_dir: str, out_dir: str):
+    print(os.listdir(json_dir))
+    basenames = [
+        file
+        for file in os.listdir(json_dir)
+        if os.path.isfile(os.path.join(json_dir, file)) and file.endswith(".json")
+    ]
+    for basename in basenames:
+        try:
+            json_file = os.path.join(json_dir, basename)
+            out_file = os.path.join(out_dir, basename)
+            shorten_json(json_file, out_file)
+            print(f"Shortened {basename}")
+        except ValueError:
+            print(f"Skipped {basename}")
+    print_descriptions(os.path.join(out_dir, "Descriptions.json"))
+    print("Written descriptions file")
 
 
 def main():
     parser = create_argument_parser()
     args = parser.parse_args(sys.argv[1:])
-    shorten_json(vars(args)["json_file"], vars(args)["output_file"])
+    shorten_jsons(vars(args)["json_dir"], vars(args)["out_dir"])
 
 
 if __name__ == "__main__":

--- a/Descriptions/main.py
+++ b/Descriptions/main.py
@@ -2,7 +2,7 @@ import argparse
 import sys
 import os
 
-from descriptions import DescriptionStore, shorten_json
+from descriptions import DescriptionStore
 
 
 def create_argument_parser():
@@ -11,37 +11,69 @@ def create_argument_parser():
         description="Gakuen Idolm@ster card description conversion tool",
     )
     subparsers = parser.add_subparsers()
-    parser_extract = subparsers.add_parser("shorten", help="Shortens json files")
-    parser_extract.add_argument("json_dir", help="The folder containing the json files")
-    parser_extract.add_argument(
+    parser_shorten = subparsers.add_parser("shorten", help="Shortens json files")
+    parser_shorten.add_argument("in_dir", help="The folder containing the json files")
+    parser_shorten.add_argument(
         "out_dir", help="The folder to contain the output files"
     )
+    parser_shorten.set_defaults(func=shorten_jsons)
+    parser_lengthen = subparsers.add_parser("lengthen", help="Lengthens json files")
+    parser_lengthen.add_argument(
+        "in_dir", help="The folder containing the shortened json files"
+    )
+    parser_lengthen.add_argument(
+        "out_dir", help="The folder to contain the output files"
+    )
+    parser_lengthen.set_defaults(func=lengthen_jsons)
     return parser
 
+descriptions_filename = "Descriptions.json"
 
-def shorten_jsons(json_dir: str, out_dir: str):
+
+def shorten_jsons(args):
+    in_dir = args["in_dir"]
+    out_dir = args["out_dir"]
     description_store = DescriptionStore()
     basenames = [
-        file
-        for file in os.listdir(json_dir)
-        if os.path.isfile(os.path.join(json_dir, file)) and file.endswith(".json")
+        basename
+        for basename in os.listdir(in_dir)
+        if os.path.isfile(os.path.join(in_dir, basename)) and basename.endswith(".json")
     ]
     for basename in basenames:
         try:
-            json_file = os.path.join(json_dir, basename)
+            in_file = os.path.join(in_dir, basename)
             out_file = os.path.join(out_dir, basename)
-            shorten_json(description_store, json_file, out_file)
+            description_store.shorten_json(in_file, out_file)
             print(f"Shortened {basename}")
         except ValueError:
             print(f"Skipped {basename}")
-    description_store.print_descriptions(os.path.join(out_dir, "Descriptions.json"))
+    description_store.print_descriptions(os.path.join(out_dir, descriptions_filename))
     print("Written descriptions file")
+
+
+def lengthen_jsons(args):
+    in_dir = args["in_dir"]
+    out_dir = args["out_dir"]
+    description_store = DescriptionStore()
+    description_store.load_descriptions(os.path.join(in_dir, descriptions_filename))
+    basenames = [
+        basename
+        for basename in os.listdir(in_dir)
+        if os.path.isfile(os.path.join(in_dir, basename))
+        and basename.endswith(".json")
+        and basename != descriptions_filename
+    ]
+    for basename in basenames:
+        in_file = os.path.join(in_dir, basename)
+        out_file = os.path.join(out_dir, basename)
+        description_store.lengthen_json(in_file, out_file)
+        print(f"Lengthened {basename}")
 
 
 def main():
     parser = create_argument_parser()
     args = parser.parse_args(sys.argv[1:])
-    shorten_jsons(vars(args)["json_dir"], vars(args)["out_dir"])
+    args.func(vars(args))
 
 
 if __name__ == "__main__":

--- a/Descriptions/main.py
+++ b/Descriptions/main.py
@@ -2,7 +2,7 @@ import argparse
 import sys
 import os
 
-from descriptions import shorten_json, print_descriptions
+from descriptions import DescriptionStore, shorten_json
 
 
 def create_argument_parser():
@@ -20,7 +20,7 @@ def create_argument_parser():
 
 
 def shorten_jsons(json_dir: str, out_dir: str):
-    print(os.listdir(json_dir))
+    description_store = DescriptionStore()
     basenames = [
         file
         for file in os.listdir(json_dir)
@@ -30,11 +30,11 @@ def shorten_jsons(json_dir: str, out_dir: str):
         try:
             json_file = os.path.join(json_dir, basename)
             out_file = os.path.join(out_dir, basename)
-            shorten_json(json_file, out_file)
+            shorten_json(description_store, json_file, out_file)
             print(f"Shortened {basename}")
         except ValueError:
             print(f"Skipped {basename}")
-    print_descriptions(os.path.join(out_dir, "Descriptions.json"))
+    description_store.print_descriptions(os.path.join(out_dir, "Descriptions.json"))
     print("Written descriptions file")
 
 

--- a/Descriptions/main.py
+++ b/Descriptions/main.py
@@ -1,7 +1,7 @@
 import argparse
 import sys
 
-from descriptions import process_json
+from descriptions import shorten_json
 
 
 def create_argument_parser():
@@ -19,7 +19,7 @@ def create_argument_parser():
 def main():
     parser = create_argument_parser()
     args = parser.parse_args(sys.argv[1:])
-    process_json(vars(args)["json_file"], vars(args)["output_file"])
+    shorten_json(vars(args)["json_file"], vars(args)["output_file"])
 
 
 if __name__ == "__main__":

--- a/Descriptions/main.py
+++ b/Descriptions/main.py
@@ -1,0 +1,26 @@
+import argparse
+import sys
+
+from descriptions import process_json
+
+
+def create_argument_parser():
+    parser = argparse.ArgumentParser(
+        prog="Gakumas Card Description Parser",
+        description="Gakuen Idolm@ster card description conversion tool",
+    )
+    subparsers = parser.add_subparsers()
+    parser_extract = subparsers.add_parser("extract", help="Extracts data")
+    parser_extract.add_argument("json_file", help="The json file")
+    parser_extract.add_argument("output_file", help="The output file")
+    return parser
+
+
+def main():
+    parser = create_argument_parser()
+    args = parser.parse_args(sys.argv[1:])
+    process_json(vars(args)["json_file"], vars(args)["output_file"])
+
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -48,6 +48,34 @@ To force the program to process all spreadsheet files, include the flag `-a`
 pipenv run python Gakumas-Tool/main.py inject -a in_txt_directory xlsx_directory out_txt_directory
 ```
 
+### Shortening .json files with descriptions
+
+Some .json files needed for translation (e.g. those in the folder `gakumasu-diff/json`
+in http://github.com/Kajaqq/gakumas-master-translation-en) are very large,
+due to having many repeated description objects.
+
+The script in the `Descriptions` folder shortens these files to facilitate editing
+and translation.
+It goes through each .json file in the input folder, and for those with description
+objects, generates a new .json file with all description objects replaced with key strings
+or indices instead.
+It also generates a `Descriptions.json` file, which contains a dictionary of all
+the description objects.
+
+You can then translate the text fields in the `Descriptions.json` file,
+and then run the lengthening script to generate the full .json files
+using the `Descriptions.json`.
+
+To shorten .json files in a folder, run
+```bash
+pipenv run python Descriptions/main.py shorten in_directory out_directory
+```
+
+To generate the full .json files, run
+```bash
+pipenv run python Descriptions/main.py lengthen in_directory out_directory
+```
+
 
 ## Other useful repositories
 


### PR DESCRIPTION
New script to help the process of translating files like `ProduceCard.json`, that contain "description objects".
These are objects of the form
```json
{
  "produceDescriptionType": something,
  "examDescriptionType": something,
  "examEffectType": something,
  "produceCardCategory": something,
  "produceCardMovePositionType": something,
  "produceStepType": something,
  "targetId": something,
  "text": something
}
```

Basically it works like this:
1. Have the original json files in a folder `original_json`, and empty folders `shortened` and `translated_json`
2. Run the shorten script on `original_json` to generate shortened files in `shortened`
3. Translate the files in `shortened`. Note that you don't need to touch any of the strings that look like `"plaintext:japanese_text"` because those are used as keys, not actual data
4. Run the lengthen script to generate the full translated .json files in `translated_json`